### PR TITLE
chore: pin Node 24.x and stop Dependabot preview deploys

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "nuxt-app",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": "24.x"
+  },
   "scripts": {
     "build": "nuxt build",
     "dev": "nuxt dev",

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "dependabot/**": false
+    }
+  }
+}


### PR DESCRIPTION
## What

- **Node 24.x**: added `engines.node: "24.x"` to `package.json` and set the Vercel project's Node.js Version to 24.x. Node 20 is EOL on Vercel with builds disabled **2026-09-30**; 24 is the current LTS. `engines.node` overrides the dashboard setting and version-controls the runtime.
- **`vercel.json`**: disables automatic Vercel deployments for `dependabot/**` branches so Dependabot PRs stop consuming build compute.

## Why the globstar

Vercel matches branch patterns with [minimatch](https://github.com/isaacs/minimatch), where `*` does not cross `/`. Dependabot branches are `dependabot/npm_and_yarn/...` (multiple slashes), so `dependabot/**` is required — `dependabot/*` would not match.

`dev` (preview) and `main` (prod) deployments are unaffected.